### PR TITLE
Update ports properties and README

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,16 +21,21 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [3000],
 
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "yarn install",
-
 	// Use 'portsAttributes' to set default properties for specific forwarded ports.
+	// You can use a port number (i.e. 3000), range of numbers, or a regex to match the running process.
 	"portsAttributes": {
-		"3000": {
-			"label": "Hello Remote World",
-			"onAutoForward": "notify"
+		".+/server.js": {
+			"label": "Hello Remote World"
 		}
 	},
+
+	// Use 'otherPortsAttributes' to configure any ports that aren't configured using 'portsAttributes'.
+	// "otherPortsAttributes": {
+	// 		"onAutoForward": "silent"
+	// },
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "yarn install",
 
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "node"

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Some things to try:
    - Continue (<kbd>F5</kbd>). You can connect to the server in the container by either: 
       - Clicking on `Open in Browser` in the notification telling you: `Your service running on port 3000 is available`.
       - Clicking the globe icon in the 'Ports' view. The 'Ports' view gives you an organized table of your forwarded ports, and you can access it with the command **Ports: Focus on Ports View**.
-   - Notice port 3000 in the 'Ports' view is labeled "Hello Remote World." In `devcontainer.json`, you can set `"portsAttributes"`, such as a label for your forwarded ports and the action to be taken when the port is autoforwarded.
+   - Notice port 3000 in the 'Ports' view is labeled "Hello Remote World." In `devcontainer.json`, you can set `"portsAttributes"`, such as a label for your forwarded ports and the action to be taken when the port is autoforwarded. 
 
    > **Note:** In Remote - Containers, you can access your app at `http://localhost:3000` in a local browser. But in a browser-based Codespace, you must click the link from the notification or the `Ports` view so that the service handles port forwarding in the browser and generates the correct URL.
    
@@ -61,12 +61,10 @@ Some things to try:
 
    You may want to make changes to your container, such as installing a different version of a software or forwarding a new port. You'll rebuild your container for your changes to take effect. 
    
-   **Forward a port statically:** As an example change, let's forward a port statically in the `.devcontainer/devcontainer.json` file. 
-     
-   > **Note:** Remote-Containers and Codespaces also take care of dynamic port forwarding, but there may be instances in which we want to statically declare a forwarded port. 
+   **Forward a port statically:** As an example change, let's update the `portsAttributes` in the `.devcontainer/devcontainer.json` file to open a browser when our port is automatically forwarded.
    
    - Open the `.devcontainer/devcontainer.json` file.
-   - Uncomment the `forwardedPorts` attribute and adjust the port number as needed.
+   - Modify your `portsAttributes` to include a new attribute (you can add it underneath the `label` attribute): `"onAutoForward": "openBrowser"`.
    - Press <kbd>F1</kbd> and select the **Remote-Containers: Rebuild Container** or **Codespaces: Rebuild Container** command so the modifications are picked up.
 
 ## Contributing


### PR DESCRIPTION
Based on discussion in https://github.com/microsoft/vscode-remote-release/issues/4838, updating the ports properties in devcontainer.json and the README.

- Add `otherPortsAttributes` to devcontainer.json and a comment description above it, but leave it commented out 
- Group all the ports properties together sequentially in the devcontainer.json: `forwardPorts`, `portsAttributes`, `otherPortsAttributes`
- Update `portsAttributes`:
     - Replace "3000" with regex
     - Remove "notify" behavior on autoforward since it led to [two ports being shown](https://github.com/microsoft/vscode-remote-release/issues/4838#issuecomment-817772289), which could be confusing to users
     - Update in-line comment describing the property 
- Update README:
     - In the section about container rebuild to see changes take effect, it used to describe uncommenting `forwardPorts`. But with `portsAttributes` and dynamic port forwarding, it feels like making changes to attributes in this property might be the most interesting to users, so I've updated the section to describe how to open a browser on autoforward. 

Please let me know any thoughts you have on the above changes - happy to discuss further, make some modifications, or describe things more clearly for users via comments or the README.

Once we decide on a format that works well for the devcontainer.json and README here, I'll extend the same to the other remote samples and merge in changes there. 