### PR TITLE
chore(devcontainer): bump javascript-node image version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 {
 	"name": "Node.js",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-18-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:3-22-bookworm",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},


### PR DESCRIPTION
## Summary

Chore:
- Bump [javascript-node image](https://github.com/devcontainers/images/tree/main/src/javascript-node) version in [devcontainer.json](https://github.com/microsoft/vscode-remote-try-node/blob/main/.devcontainer/devcontainer.json) to the updated release

## Description

[[javascript-node, typescript-node] - Node 18 EOL changes. #1391](https://github.com/devcontainers/images/pull/1391) deleted mcr.microsoft.com/devcontainers/javascript-node:1-18-bullseye image.

This PR updated Node to use current LTS version.